### PR TITLE
Add library.properties metadata file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-*.properties
 *.development

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=MCP3911_Arduino_Library
+version=0.0.0
+author=architecture-building-systems
+maintainer=architecture-building-systems
+sentence=A library for the Microchip MCP3911 analog front end.
+paragraph=
+category=Device Control
+url=https://github.com/architecture-building-systems/MCP3911_Arduino_Library
+architectures=avr


### PR DESCRIPTION
The Arduino Library 1.5 format adopted in https://github.com/architecture-building-systems/MCP3911_Arduino_Library/commit/aa2c939909313b1244eda84ad2320a6403c9495d requires that a library.properties file be located in the root of the library folder in order for the Arduino IDE to recognize the library.

library.properties format is documented here:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format